### PR TITLE
Fix windows support

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,7 +49,7 @@ static HARDCODED_NAMES: &[&str] = &[
     // not to break compatibility, we still prefer CLI over GUI)
     "open -Wt",
     // GUI editors
-    "code -w", "atom -w", "subl", "gvim", "mate",
+    "code -w", "atom -w", "subl -w", "gvim", "mate",
     // Generic "file openers"
     "open -a TextEdit",
     "open -a TextMate",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,11 +44,17 @@ static HARDCODED_NAMES: &[&str] = &[
 static HARDCODED_NAMES: &[&str] = &[
     // CLI editors
     "nano", "pico", "vim", "nvim", "vi", "emacs",
+    // open has a special flag to open in the default text editor
+    // (this really should come before the CLI editors, but in order
+    // not to break compatibility, we still prefer CLI over GUI)
+    "open -Wt",
     // GUI editors
-    "code", "atom", "subl", "gvim", "mate",
+    "code -w", "atom -w", "subl", "gvim", "mate",
     // Generic "file openers"
     "open -a TextEdit",
     "open -a TextMate",
+    // TODO: "open -f" reads input from standard input and opens with
+    // TextEdit. if this flag were used we could skip the tempfile
     "open",
 ];
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,16 +71,20 @@ static HARDCODED_NAMES: &[&str] = &[
 ];
 
 #[cfg(feature = "better-path")]
-fn get_full_editor_path<T: AsRef<OsStr>>(binary_name: T) -> which::Result<PathBuf> {
-    which(binary_name)
+fn get_full_editor_path<T: AsRef<OsStr>>(binary_name: T) -> Result<PathBuf> {
+    let path = which(binary_name);
+    if path.is_ok(){
+        return Ok(path.unwrap());
+    }
+    Err(Error::from(ErrorKind::NotFound))
 }
 
 #[cfg(not(feature = "better-path"))]
-fn get_full_editor_path<T: AsRef<OsStr>>(binary_name: T) -> which::Result<PathBuf> {
+fn get_full_editor_path<T: AsRef<OsStr> + AsRef<std::path::Path>>(binary_name: T) -> Result<PathBuf> {
     if let Some(paths) = env::var_os("PATH") {
         for dir in env::split_paths(&paths) {
             if dir.join(&binary_name).is_file() {
-                Ok(dir.join(&binary_name))
+                return Ok(dir.join(&binary_name));
             }
         }
     }


### PR DESCRIPTION
This fixes a number of issues on Windows:

- VS code was not being found because it is not usually on the path; by default, VS Code installs "code.cmd" to the path. Unfortunately, without the full path, "code.cmd" will fail to run. Because of this, we're now passing the full path to the editor to the command.
- notepad++ does not block at all regardless of what flags you pass, so it was removed.
- without the -w flag, VS code will not block when opening the file, so it was added. Same with atom and subl.

This is based on your graphical-editor-flags branch, so it includes those commits too. I've tested this on both Windows and MacOS.