### PR TITLE
allow absolute paths if they exist.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/milkey-mouse/edit"
 keywords = ["editor", "edit", "editing", "cli"]
 categories = ["command-line-interface", "config", "text-processing", "text-editors"]
 license = "CC0-1.0"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2018"
 
 [lib]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,11 +98,11 @@ fn string_to_cmd(s: String) -> (PathBuf, Vec<String>) {
 
 fn get_full_editor_cmd(s: String) -> Result<(PathBuf, Vec<String>)> {
     let (path, args) = string_to_cmd(s);
-    let result = get_full_editor_path(path);
-    if result.is_err() {
-        return Err(Error::from(ErrorKind::NotFound));
+    match get_full_editor_path(&path) {
+        Ok(result) => Ok((result, args)),
+        Err(_) if path.exists() => Ok((path, args)),
+        Err(_) => Err(Error::from(ErrorKind::NotFound))
     }
-    Ok((result.unwrap(), args))
 }
 
 fn get_editor_args() -> Result<(PathBuf, Vec<String>)> {


### PR DESCRIPTION
If a user's `EDITOR` is an absolute path to something that isn't actually in their `PATH`, the `which` function doesn't seem to pick it up; it gets ignored which in turn causes `get_full_editor_path` to fail. 
This change just makes it so that if `which` fails, but the path specified by the user points to an existing entity, the existing entity gets used instead of the fallback.

My `EDITOR` variable is an absolute path to my nvim binary, but a program I'm using that depends on this crate keeps showing me nano as a fallback.