### PR TITLE
Add functions allowing users to abandon changes.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/milkey-mouse/edit"
 keywords = ["editor", "edit", "editing", "cli"]
 categories = ["command-line-interface", "config", "text-processing", "text-editors"]
 license = "CC0-1.0"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2018"
 
 [lib]


### PR DESCRIPTION
The current set of editing functions will always save the contents
of the buffer. In cases where exiting the editor will trigger some
action (something like editing a git commit message) one may want
to give users the optoin of abandoning their changes by
quitting the editor without saving ala `:q!` in vim.

The implementation just notes the `modified` time associated with the
tempfile and compares it to the `modified` time after editing. If
they're the same, an empty buffer is returned instead of the contents
of the tempfile.