### PR TITLE
feat: added support for quoted env variables with shell-words

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,9 @@ path = "src/bin.rs"
 [features]
 default = ["better-path"]
 better-path = ["which"]
+quoted-env = ["shell-words"]
 
 [dependencies]
+shell-words = { version = "1.1.0", optional = true }
 tempfile = "3.1.0"
 which = { version = "4.0", default-features = false, optional = true }


### PR DESCRIPTION
This commit adds a new cargo feature, `quoted-env`.
This pulls in the `shell-words` dependency.

Normally with the `$EDITOR` env variable being something like \
`'C:/Program Files/Notepad++/notepad++.exe' -multiInst -notabbar -nosession` \
will cause an error because the current implementation uses `str::split_ascii_whitespace`.

With the `quoted-env` feature enabled, this process is handled by `shell_words::split`.
(On an error, it still falls-back to the original method.)

> I've enabled this feature by default, we could change it.
> I've also not bumped any version, though a minor version bump seems right; let me know if I should do that.

## Bug Fixes
Also fixed a clippy lint: `clippy::unused_io_amount` (The fix was to use `write_all` instead of just `write`)
