### PR TITLE
Support Debian's sensible-editor

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,7 +32,7 @@ static ENV_VARS: &[&str] = &["VISUAL", "EDITOR"];
 #[rustfmt::skip]
 static HARDCODED_NAMES: &[&str] = &[
     // CLI editors
-    "nano", "pico", "vim", "nvim", "vi", "emacs",
+    "sensible-editor", "nano", "pico", "vim", "nvim", "vi", "emacs",
     // GUI editors
     "code", "atom", "subl", "gedit", "gvim",
     // Generic "file openers"


### PR DESCRIPTION
Debian and derivative distros include a program named `sensible-editor` that is similar in spirit to `get_editor()`, except it also allows the user to make an interactive choice when the relevant envvars are unset:

- It invokes `$VISUAL` or `$EDITOR` if they are defined
- Otherwise, the program specified in `~/.selected_editor` is run.  If this file does not exist and input is a tty, the user is shown a list of installed text editors and asked to choose one.  The choice is saved in `~/.selected_editor`, and then the given program is run.
- If the file does not exist and input is not a tty, or if the program saved in `~/.selected_editor` no longer exists, `sensible-editor` falls back to `nano`, then `nano-tiny`, then `vi`.

This patch adds `sensible-editor` to the list of editors considered on non-Windows, non-macOS systems so that determining an editor to use on Debian systems works similarly to other programs on Debian.